### PR TITLE
Use winston rotating logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
   "license": "MIT",
   "dependencies": {
     "express": "^5.1.0",
-    "socket.io": "^4.8.1"
+    "socket.io": "^4.8.1",
+    "winston": "^3.8.2",
+    "winston-daily-rotate-file": "^4.7.1"
   }
 }

--- a/server.js
+++ b/server.js
@@ -3,11 +3,29 @@ import http from "http";
 import { Server } from "socket.io";
 import path from "path";
 import { fileURLToPath } from "url";
-import { appendFile } from "fs/promises";
+import { createLogger, format, transports } from "winston";
+import DailyRotateFile from "winston-daily-rotate-file";
 
 const app = express();
 const server = http.createServer(app);
 const io = new Server(server);
+
+const logPath = process.env.LOG_PATH || "chat.log";
+const logger = createLogger({
+  level: "info",
+  format: format.combine(
+    format.timestamp(),
+    format.printf(({ timestamp, message }) => `${timestamp} ${message}`)
+  ),
+  transports: [
+    new DailyRotateFile({
+      filename: logPath,
+      maxSize: "20m",
+      maxFiles: "14d",
+    }),
+    new transports.Console(),
+  ],
+});
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 app.use(express.static(path.join(__dirname, "public")));
@@ -16,29 +34,21 @@ io.on("connection", (socket) => {
   let ip = socket.handshake.address;
   if (ip.startsWith("::ffff:")) ip = ip.replace("::ffff:", "");
 
-  console.log(`✅ Usuario conectado desde ${ip}`);
+  logger.info(`✅ Usuario conectado desde ${ip}`);
 
-  socket.on("chat message", async (msg) => {
-    const timestamp = new Date().toISOString();
+  socket.on("chat message", (msg) => {
     const messageWithIp = `[${ip}] ${msg}`;
-    const logLine = `${timestamp} ${messageWithIp}\n`;
 
-    console.log(messageWithIp);
     io.emit("chat message", messageWithIp);
-
-    try {
-      await appendFile("chat.log", logLine, "utf8");
-    } catch (err) {
-      console.error("❌ Error escribiendo log:", err);
-    }
+    logger.info(messageWithIp);
   });
 
   socket.on("disconnect", () => {
-    console.log(`❌ Usuario desconectado desde ${ip}`);
+    logger.info(`❌ Usuario desconectado desde ${ip}`);
   });
 });
 
 const PORT = process.env.PORT || 3000;
-server.listen(PORT, () =>
-  console.log(`🟢 Servidor en http://localhost:${PORT}`)
-);
+server.listen(PORT, () => {
+  logger.info(`🟢 Servidor en http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- switch logging to `winston` with daily rotate file
- expose log location through `LOG_PATH` env var

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ec64ecea0833293007ed33993332e