### PR TITLE
Handle listen errors

### DIFF
--- a/server.js
+++ b/server.js
@@ -39,6 +39,11 @@ io.on("connection", (socket) => {
 });
 
 const PORT = process.env.PORT || 3000;
-server.listen(PORT, () =>
-  console.log(`🟢 Servidor en http://localhost:${PORT}`)
-);
+server.listen(PORT, (err) => {
+  if (err) {
+    console.error("❌ Error iniciando el servidor:", err);
+    process.exit(1);
+    return;
+  }
+  console.log(`🟢 Servidor en http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- log errors from `server.listen`
- exit process if startup fails

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ec62c39908332996f73543e3ec16e