### PR TITLE
Fix duplicate socket.io declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "devDependencies": {
     "@eslint/js": "^8.56.0",
     "eslint": "^9.29.0",
-    "socket.io": "^4.8.1",
     "winston": "^3.8.2",
     "winston-daily-rotate-file": "^4.7.1"
   }


### PR DESCRIPTION
## Summary
- remove redundant `socket.io` from devDependencies

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ecdcba00c833283fb7c09cba84a8f