### PR TITLE
Add emoji picker to chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ A lightweight chat application built with Node.js, Express and Socket.IO. The se
    ```bash
    npm install
    ```
+   The emoji picker is loaded from a CDN using the
+   [`emoji-picker-element`](https://github.com/nolanlawson/emoji-picker-element)
+   library, so no additional packages are required.
 
 ## Running the server
 

--- a/public/index.html
+++ b/public/index.html
@@ -35,6 +35,7 @@
     }
 
     #form {
+      position: relative;
       display: flex;
       padding: 0.5em;
       gap: 0.5em;
@@ -50,6 +51,13 @@
       border-radius: 4px;
     }
 
+    #emoji-btn {
+      background: none;
+      border: none;
+      font-size: 1.5em;
+      cursor: pointer;
+    }
+
     #send {
       padding: 0.8em 1.2em;
       font-size: 1em;
@@ -57,6 +65,13 @@
       color: white;
       border: none;
       border-radius: 4px;
+    }
+
+    #emoji-picker {
+      position: absolute;
+      bottom: 3.2em;
+      right: 0.5em;
+      display: none;
     }
 
     #send:hover {
@@ -68,10 +83,13 @@
   <ul id="messages"></ul>
   <form id="form">
     <input id="input" autocomplete="off" placeholder="Escribe tu mensaje..." />
+    <button type="button" id="emoji-btn">😊</button>
     <button id="send">Enviar</button>
+    <emoji-picker id="emoji-picker"></emoji-picker>
   </form>
 
   <script src="/socket.io/socket.io.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/emoji-picker-element@1"></script>
   <script>
     const nickname = prompt('Ingresa un apodo:');
     const socket = io();
@@ -79,6 +97,16 @@
     const form = document.getElementById('form');
     const input = document.getElementById('input');
     const messages = document.getElementById('messages');
+    const emojiBtn = document.getElementById('emoji-btn');
+    const emojiPicker = document.getElementById('emoji-picker');
+    emojiBtn.addEventListener('click', () => {
+      emojiPicker.style.display = emojiPicker.style.display === 'none' ? 'block' : 'none';
+    });
+    emojiPicker.addEventListener('emoji-click', event => {
+      input.value += event.detail.emoji.unicode;
+      emojiPicker.style.display = 'none';
+      input.focus();
+    });
     let sessionId;
 
     socket.on('chat history', function(data) {

--- a/server.js
+++ b/server.js
@@ -6,6 +6,7 @@ import { fileURLToPath } from "url";
 import { randomUUID } from "crypto";
 import { createLogger, format, transports } from "winston";
 import DailyRotateFile from "winston-daily-rotate-file";
+import { formatMessage } from "./utils.js";
 
 const app = express();
 const server = http.createServer(app);
@@ -52,7 +53,7 @@ io.on("connection", (socket) => {
   socket.emit("chat history", { sessionId, history: chatHistory });
 
   socket.on("chat message", (msg) => {
-    const messageWithInfo = `[${ip}] [${nickname}] ${msg}`;
+    const messageWithInfo = formatMessage(ip, nickname, msg);
 
     chatHistory.push(messageWithInfo);
     io.emit("chat message", messageWithInfo);
@@ -65,12 +66,17 @@ io.on("connection", (socket) => {
   });
 });
 
-const PORT = process.env.PORT || 3000;
-server.listen(PORT, (err) => {
-  if (err) {
-    logger.error("❌ Error iniciando el servidor:", err);
-    process.exit(1);
-    return;
-  }
-  logger.info(`🟢 Servidor en http://localhost:${PORT}`);
-});
+export function startServer(port = process.env.PORT || 3000) {
+  server.listen(port, (err) => {
+    if (err) {
+      logger.error("❌ Error iniciando el servidor:", err);
+      process.exit(1);
+      return;
+    }
+    logger.info(`🟢 Servidor en http://localhost:${port}`);
+  });
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  startServer();
+}

--- a/test/emoji.test.js
+++ b/test/emoji.test.js
@@ -1,0 +1,8 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { formatMessage } from '../utils.js';
+
+test('formatMessage handles emoji', () => {
+  const res = formatMessage('1.2.3.4', 'user', 'hola 😊');
+  assert.strictEqual(res, '[1.2.3.4] [user] hola 😊');
+});

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,3 @@
+export function formatMessage(ip, nickname, msg) {
+  return `[${ip}] [${nickname}] ${msg}`;
+}


### PR DESCRIPTION
## Summary
- add emoji-picker-element to the frontend
- allow selecting emoji and appending it to chat input
- export a helper to format messages
- update README with emoji library info
- test emoji handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ed2de39448332a365645f8113e561