### PR TITLE
Move winston packages to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,13 @@
       "license": "MIT",
       "dependencies": {
         "express": "^5.1.0",
-        "socket.io": "^4.8.1"
+        "socket.io": "^4.8.1",
+        "winston": "^3.8.2",
+        "winston-daily-rotate-file": "^4.7.1"
       },
       "devDependencies": {
         "@eslint/js": "^8.56.0",
-        "eslint": "^9.29.0",
-        "winston": "^3.8.2",
-        "winston-daily-rotate-file": "^4.7.1"
+        "eslint": "^9.29.0"
       }
     },
     "node_modules/@colors/colors": {

--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
   "license": "MIT",
   "dependencies": {
     "express": "^5.1.0",
-    "socket.io": "^4.8.1"
+    "socket.io": "^4.8.1",
+    "winston": "^3.8.2",
+    "winston-daily-rotate-file": "^4.7.1"
   },
   "devDependencies": {
     "@eslint/js": "^8.56.0",
-    "eslint": "^9.29.0",
-    "winston": "^3.8.2",
-    "winston-daily-rotate-file": "^4.7.1"
+    "eslint": "^9.29.0"
   }
 }


### PR DESCRIPTION
## Summary
- move `winston` and `winston-daily-rotate-file` from devDependencies into dependencies
- update `package-lock.json`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ed8c1b70c8332b7c52238b2f45030