### PR TITLE
Fix emoji test to expect newline output

### DIFF
--- a/test/emoji.test.js
+++ b/test/emoji.test.js
@@ -4,5 +4,5 @@ import { formatMessage } from '../utils.js';
 
 test('formatMessage handles emoji', () => {
   const res = formatMessage('1.2.3.4', 'user', 'hola 😊');
-  assert.strictEqual(res, '[1.2.3.4] [user] hola 😊');
+  assert.strictEqual(res, '[1.2.3.4] [user]:\nhola 😊');
 });


### PR DESCRIPTION
## Summary
- update emoji test to match the newline format from `formatMessage`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684eebdf88188332b874c5a2555c481c